### PR TITLE
fix(desktop nav): fixed in correct href on drivers list navigation dr…

### DIFF
--- a/src/components/navigation/_Components/desktop/_components/drivers-list.tsx
+++ b/src/components/navigation/_Components/desktop/_components/drivers-list.tsx
@@ -42,7 +42,7 @@ const DriverBadge = ({ driver }: driverBadgeProps) => {
                     onMouseLeave={(e) => {
                         e.currentTarget.style.backgroundColor = '';
                     }}
-                    href={`/${driver.givenName}-${driver.familyName}`}>
+                    href={`/drivers/${driver.givenName}-${driver.familyName}`}>
                     <div className='flex justify-center gap-1'>
                         <span
                             className={`rounded-full overflow-hidden size-7 shadow-md ${teamBackgroundColor(driver.team.id)}`}>


### PR DESCRIPTION
the drivers list in the dekstop nav dropdown didn't have the correct herf target (`/drivers/<driver name>`). instead it had `/<driver name>`. this should be fixed with this commit.